### PR TITLE
Allow providing a customer TrustManager class for TLS

### DIFF
--- a/core/src/main/java/net/timewalker/ffmq4/FFMQClientSettings.java
+++ b/core/src/main/java/net/timewalker/ffmq4/FFMQClientSettings.java
@@ -27,6 +27,7 @@ public final class FFMQClientSettings
     public static final String TRANSPORT_TCP_CONNECT_TIMEOUT = "transport.tcp.connectTimeout";
     public static final String TRANSPORT_TCP_SSL_PROTOCOL = "transport.tcp.ssl.protocol";
     public static final String TRANSPORT_TCP_SSL_IGNORE_CERTS = "transport.tcp.ssl.ignoreCertificates";
+    public static final String TRANSPORT_TCP_SSL_TRUST_MANAGER = "transport.tcp.ssl.trustManager";
     
     // Consumer related
     public static final String CONSUMER_SEND_ACKS_ASYNC = "consumer.sendAcksAsync";

--- a/core/src/main/java/net/timewalker/ffmq4/transport/tcp/io/TcpPacketTransport.java
+++ b/core/src/main/java/net/timewalker/ffmq4/transport/tcp/io/TcpPacketTransport.java
@@ -155,6 +155,7 @@ public final class TcpPacketTransport extends AbstractTcpPacketTransport
         {
             String sslProtocol = settings.getStringProperty(FFMQClientSettings.TRANSPORT_TCP_SSL_PROTOCOL, "SSLv3");
             boolean ignoreCertificates = settings.getBooleanProperty(FFMQClientSettings.TRANSPORT_TCP_SSL_IGNORE_CERTS, false);
+            String trustManagerClass = settings.getStringProperty(FFMQClientSettings.TRANSPORT_TCP_SSL_TRUST_MANAGER);
             
             SSLContext sslContext = SSLContext.getInstance(sslProtocol);
             log.debug("#"+id+" created an SSL context : protocol=["+sslContext.getProtocol()+"] provider=["+sslContext.getProvider()+"]");
@@ -165,6 +166,8 @@ public final class TcpPacketTransport extends AbstractTcpPacketTransport
 
             if (ignoreCertificates)
                 trustManagers = new TrustManager[] { new PermissiveTrustManager() };
+            else if (trustManagerClass != null)
+                trustManagers = new TrustManager[] { (TrustManager) Class.forName(trustManagerClass, true, Thread.currentThread().getContextClassLoader()).newInstance() };
             
             sslContext.init(keyManagers,trustManagers, null);
             


### PR DESCRIPTION
We need to use a custom TrustManager to allow self-signed certificates.

This PR allows a user to define a TrustManager implementation which should be used instead of the default implementation by defining the setting `transport.tcp.ssl.trustManager` with the name of a class which implements TrustManager.